### PR TITLE
Use `env` wrapper to source bash

### DIFF
--- a/sysz
+++ b/sysz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -f # disable globbing
 shopt -s lastpipe


### PR DESCRIPTION
Will return a proper location instead of the hard-coded `/usr/bin`
Closes https://github.com/joehillen/sysz/issues/2