### PR TITLE
Add sysz script to release assets

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,15 @@
+name: Main
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: sysz

--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ VERSION: 1.2.3
 paru -S sysz
 ```
 
+## Using [`bin`](https://github.com/marcosnils/bin)
+
+```
+bin install https://github.com/joehillen/sysz
+```
+
 ## Direct Download
 
 ```sh
-wget -O ~/.bin/sysz https://raw.githubusercontent.com/joehillen/sysz/master/sysz
+wget -O ~/.bin/sysz https://github.com/joehillen/sysz/releases/latest/download/sysz
 chmod +x ~/.bin/sysz
 ```
 


### PR DESCRIPTION
This adds a github action to publish the sysz script as part of the release assets. This allows for the manual install to be safer and also lets people use `bin` to install/upgrade the script.