### PR TITLE
Add .editorconfig and sh-checker gh-action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+indent_style = space
+indent_size = 2
+
+# shfmt options
+# https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd
+shell_variant      = bash
+switch_case_indent = false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,13 @@
+name: lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run sh-checker
+        uses: luizm/action-sh-checker@master
+        with:
+          sh_checker_exclude: "README.sh"


### PR DESCRIPTION
Adds an `.editorconfig` file, including [shfmt](https://github.com/mvdan/sh) settings, compliant with the currently used formatting style. 

I also added the [sh-checker](https://github.com/luizm/action-sh-checker) github action, which was linked in the shfmt readme.
It enforces [shellcheck](https://github.com/koalaman/shellcheck), [shfmt](https://github.com/mvdan/sh) and also [checkbashisms](https://linux.die.net/man/1/checkbashisms) :) 