### PR TITLE
Add --no-sudo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ A utility for using systemctl interactively via fzf.
 
 Usage: sysz [OPTS...] [CMD] [-- ARGS...]
 
-sudo is invoked automatically, if necessary.
+sudo is invoked automatically when controlling a system unit.
+If sudo is not necessary to control systemd units on your machine, it can be omitted via the '--no-sudo' flag.
 
 If only one unit is chosen, available commands will be presented
 based on the state of the unit (e.g. "start" only shows if unit is "active").
@@ -75,6 +76,7 @@ OPTS:
   -u, --user               Only show --user units
   --sys, --system          Only show --system units
   -s STATE, --state STATE  Only show units in STATE (repeatable)
+  --no-sudo                Do not invoke sudo
   -V, --verbose            Print the systemctl command
   -v, --version            Print the version
   -h, --help               Print this message

--- a/README.sh
+++ b/README.sh
@@ -6,6 +6,8 @@ cat <<EOF >README.md
 
 A [fzf](https://github.com/junegunn/fzf) terminal UI for systemctl
 
+<a href="https://console.dev" title="Visit Console - the best tools for developers"><img src="https://console.dev/img/badges/1.0/svg/console-badge-logo-dark.svg" alt="Console - Developer Tool of the Week" /></a>
+
 # Demo
 
 [![asciicast](https://asciinema.org/a/BLsJz73uF7DdQj7FVGqLPhqCa.svg)](https://asciinema.org/a/BLsJz73uF7DdQj7FVGqLPhqCa)

--- a/sysz
+++ b/sysz
@@ -103,24 +103,18 @@ _sysz_systemctl() {
 }
 
 _sysz_journalctl() {
-  # remove --system from journalctl
-  if [[ $1 = --system ]]; then
-    shift
+  if [[ $1 = --user ]]; then
+    # use --user-unit flag if it's a user unit
+    _sysz_run journalctl --user-unit="$2" "${@:3}"
+  else
     if [[ $EUID -ne 0 ]]; then
-      # only run sudo if we aren't root and it's a system unit
-      _sysz_run sudo journalctl "$@"
-      return
+      # only run sudo if we aren't root
+      _sysz_run sudo journalctl --unit="$2" "${@:3}"
+    else
+      _sysz_run journalctl --unit="$2" "${@:3}"
     fi
   fi
 
-  # remove --user flag from journalctl
-  # --user and --system don't work the same on journalctl
-  # as they do for systemctl
-  if [[ $1 = --user ]]; then
-    shift
-  fi
-
-  _sysz_run journalctl "$@"
 }
 
 _sysz_manager() {
@@ -557,10 +551,10 @@ for PICK in "${UNITS[@]}"; do
   for CMD in "${CMDS[@]}"; do
     case ${CMD%% *} in
     journal)
-      _sysz_journalctl "$MANAGER" -xe "--unit=$UNIT" "${ARGS[@]}"
+      _sysz_journalctl "$MANAGER" "$UNIT" -xe "${ARGS[@]}"
       ;;
     follow)
-      _sysz_journalctl "$MANAGER" -xef "--unit=$UNIT" "${ARGS[@]}"
+      _sysz_journalctl "$MANAGER" "$UNIT" -xef "${ARGS[@]}"
       ;;
     status)
       # shellcheck disable=2086

--- a/sysz
+++ b/sysz
@@ -30,7 +30,8 @@ A utility for using systemctl interactively via fzf.
 
 Usage: $PROG [OPTS...] [CMD] [-- ARGS...]
 
-sudo is invoked automatically, if necessary.
+sudo is invoked automatically when controlling a system unit.
+If sudo is not necessary to control systemd units on your machine, it can be omitted via the "--no-sudo" flag.
 
 If only one unit is chosen, available commands will be presented
 based on the state of the unit (e.g. "start" only shows if unit is "active").
@@ -39,6 +40,7 @@ OPTS:
   -u, --user               Only show --user units
   --sys, --system          Only show --system units
   -s STATE, --state STATE  Only show units in STATE (repeatable)
+  --no-sudo                Do not invoke sudo
   -V, --verbose            Print the systemctl command
   -v, --version            Print the version
   -h, --help               Print this message
@@ -93,8 +95,13 @@ _sysz_run() {
   eval "$@" || return $?
 }
 
+_sysz_use_sudo() {
+  # returns true if '--no-sudo' flag is unset and if the user is not root
+  [[ $NO_SUDO != true ]] && [ $EUID -ne 0 ]
+}
+
 _sysz_systemctl() {
-  if [[ $EUID -ne 0 && $1 = --system ]]; then
+  if [[ $1 = --system ]] && _sysz_use_sudo; then
     # only run sudo if we aren't root and it's a system unit
     _sysz_run sudo systemctl "$@"
   else
@@ -107,7 +114,7 @@ _sysz_journalctl() {
     # use --user-unit flag if it's a user unit
     _sysz_run journalctl --user-unit="$2" "${@:3}"
   else
-    if [[ $EUID -ne 0 ]]; then
+    if _sysz_use_sudo; then
       # only run sudo if we aren't root
       _sysz_run sudo journalctl --unit="$2" "${@:3}"
     else
@@ -266,6 +273,10 @@ while [[ -n $1 ]]; do
     ;;
   --state=*)
     STATES+=("$1")
+    shift
+    ;;
+  --no-sudo)
+    NO_SUDO=true
     shift
     ;;
   -v | --version)


### PR DESCRIPTION
As explained in https://github.com/joehillen/sysz/issues/18#issuecomment-988382418, this change adds a `--no-sudo` flag to omit invoking `sudo` altogether.

**Note:** This branch is based on #19, because of otherwise conflicting changes. Please merge #19 first.