### PR TITLE
minor: Enable fzf sort

### DIFF
--- a/sysz
+++ b/sysz
@@ -423,7 +423,6 @@ while :; do
     fzf \
       --multi \
       --ansi \
-      --no-sort \
       --expect=ctrl-r,ctrl-s \
       --history="$SYSZ_HISTORY" \
       --prompt="Units: " \


### PR DESCRIPTION
Improves search result order of the (fuzzy) matches.

**Example**
_Before_ (with `--no-sort`):
![image](https://user-images.githubusercontent.com/4162215/145655614-572344ab-99f5-4249-8b0d-bdb577e02cd4.png)

_After_:
![image](https://user-images.githubusercontent.com/4162215/145655654-c3a4a8fd-a923-46a1-9c88-b0b864fc31af.png)
