### PR TITLE
wip: Better lazy input streaming, worse sorting

### DIFF
--- a/sysz
+++ b/sysz
@@ -196,7 +196,10 @@ _sysz_sort() {
 }
 
 _sysz_list() {
+
+  local MANAGER=$1
   local args
+  local color_code=''
   declare -a args
   args=(
     --all
@@ -205,30 +208,29 @@ _sysz_list() {
     --plain
     --no-pager
     "${STATES[@]}"
-    "$@"
+    "--$MANAGER"
   )
-  (
-    systemctl list-units "${args[@]}"
-    systemctl list-unit-files "${args[@]}"
-  ) | sort -u -t ' ' -k1,1 |
+  {
+    systemctl list-units "${args[@]}" | sort
+    systemctl list-unit-files "${args[@]}" | sort
+  } |
     while read -r line; do
       unit=${line%% *}
       if [[ $line = *" active "* ]]; then
-        printf '\033[0;32m%s\033[0m\n' "$unit" # green
+        color_code='32' # green
       elif [[ $line = *" failed "* ]]; then
-        printf '\033[0;31m%s\033[0m\n' "$unit" # red
+        color_code='31' # yellow
       elif [[ $line = *" not-found "* ]]; then
-        printf '\033[1;33m%s\033[0m\n' "$unit" # red
-      else
-        echo "$unit"
+        color_code='33' # orange
       fi
-    done
+      printf '[%s] \033[0;%sm%s\033[0m\n' "$MANAGER" "$color_code" "$unit"
+    done | awk '!x[$0]++'
 }
 
 _sysz_list_units() {
   for MANAGER in "${MANAGERS[@]}"; do
-    _sysz_list "--$MANAGER" | sed -e "s/^/[$MANAGER] /"
-  done | _sysz_sort
+    _sysz_list "$MANAGER"
+  done
 }
 
 # main


### PR DESCRIPTION
_Notes:_

1. For now i am just using `sort` on the individual systemctl commands, but an adjusted `_sysz_sort` could be used to keep the unit-type sorting.

2.  `awk '!x[$0]++'` can at least de-duplicate the stream without sorting 
    (i just picked the first working solution from google https://stackoverflow.com/questions/30906191/uniq-without-sorting-an-immense-text-file)  

3. moving the `sed -e "s/^/[$MANAGER] /"` logic into `_sysz_list` isn't necessary, but i think it's a bit cleaner.

4.  Are curly brackets (= no sub-shell) a slightly better choice here? (https://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html) 
    ```sh
    (
        [..]
    ) 
     ```
     -> 
     ```sh
    {
        [..]
    }
     ```