### PR TITLE
Added mkdir to create missing directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin install https://github.com/joehillen/sysz
 ## Direct Download
 
 ```sh
-wget -O ~/.bin/sysz https://github.com/joehillen/sysz/releases/latest/download/sysz
+mkdir -p ~/.bin/ && wget -O ~/.bin/sysz https://github.com/joehillen/sysz/releases/latest/download/sysz
 chmod +x ~/.bin/sysz
 ```
 

--- a/README.sh
+++ b/README.sh
@@ -49,7 +49,7 @@ ${BLOCK}
 ## Direct Download
 
 ${BLOCK}sh
-wget -O ~/.bin/sysz https://github.com/joehillen/sysz/releases/latest/download/sysz
+mkdir -p ~/.bin/ && wget -O ~/.bin/sysz https://github.com/joehillen/sysz/releases/latest/download/sysz
 chmod +x ~/.bin/sysz
 ${BLOCK}
 


### PR DESCRIPTION
Since `.bin` directory doesn't exists by default, `wget` will fail with `.bin/sysz: No such file or directory`

Added a mkdir for that script. 