### PR TITLE
Change --help output from stderr to stdout

### DIFF
--- a/sysz
+++ b/sysz
@@ -25,7 +25,7 @@ EOF
 }
 
 _sysz_help() {
-  cat >&2 <<EOF
+  cat <<EOF
 A utility for using systemctl interactively via fzf.
 
 Usage: $PROG [OPTS...] [CMD] [-- ARGS...]


### PR DESCRIPTION
Currently, help output cannot be reused unless the following is done.

    sysz --help 2>&1 | grep TAB

Therefore, the following process can be established.

    sysz --help | grep TAB